### PR TITLE
ACF-11 # run CSS transforms on styles within HTML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["eslint:recommended", "semistandard"],
+  "extends": [
+    "eslint:recommended",
+    "semistandard"
+  ],
   "env": {
     "amd": true,
     "browser": false,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,6 @@
     "node": true
   },
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 6
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 
 # output files
+.eslintcache
 .nyc_output
 coverage
 output

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: node_js
 node_js:
-  - "4"
-  - "stable"
-
+  - '4'
+  - '5'
+  - '6'
 before_script:
-  - export DISPLAY=:99.0
+  - 'export DISPLAY=:99.0'
   - sh -e /etc/init.d/xvfb start
+sudo: false
+env:
+  global:
+    - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+cache:
+  directories:
+    - node_modules

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-# appcache-fetcher.js
+# appcache-fetcher.js [![npm module](https://img.shields.io/npm/v/@jokeyrhyme/appcache-fetcher.svg)](https://www.npmjs.com/package/@jokeyrhyme/appcache-fetcher) [![AppVeyor Status](https://ci.appveyor.com/api/projects/status/github/jokeyrhyme/appcache-fetcher.js?branch=master&svg=true)](https://ci.appveyor.com/project/jokeyrhyme/appcache-fetcher.js) [![Travis CI Status](https://travis-ci.org/jokeyrhyme/appcache-fetcher.js.svg?branch=master)](https://travis-ci.org/jokeyrhyme/appcache-fetcher.js)
 
 store an AppCache-enabled site on disk for local use
-
-[![npm module](https://img.shields.io/npm/v/@jokeyrhyme/appcache-fetcher.svg)](https://www.npmjs.com/package/@jokeyrhyme/appcache-fetcher)
-[![travis-ci](https://img.shields.io/travis/jokeyrhyme/appcache-fetcher.js.svg)](https://travis-ci.org/jokeyrhyme/appcache-fetcher.js)
 
 
 ## Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+build: 'off'
+environment:
+  matrix:
+    - nodejs_version: '4'
+    - nodejs_version: '5'
+    - nodejs_version: '6'
+install:
+  - ps: 'Install-Product node $env:nodejs_version'
+  - npm install
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+cache:
+  - node_modules

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
     - nodejs_version: '6'
 install:
   - ps: 'Install-Product node $env:nodejs_version'
+  - npm install npm@3.3.6 -g
+  - ps: '$env:path = $env:appdata + "\npm;" + $env:path'
   - npm install
 test_script:
   - node --version

--- a/index.js
+++ b/index.js
@@ -42,16 +42,6 @@ function logErrorAndThrow (err) {
   throw err;
 }
 
-function pipeChain (stream, pipes) {
-  var head, rest;
-  if (!Array.isArray(pipes) || !pipes.length) {
-    return stream;
-  }
-  head = pipes[0];
-  rest = pipes.slice(1);
-  return pipeChain(stream.pipe(head), rest);
-}
-
 /**
  * @constructor
  * @param {Object} opts { remoteUrl: '', localPath: '' }
@@ -292,8 +282,11 @@ Fetcher.prototype.postProcessFile = function (filePath) {
   }
   console.log('postProcessFile:', filePath.replace(process.cwd(), ''));
   return new Promise((resolve, reject) => {
-    pipeChain(vfs.src([ filePath ]), transforms.map((tf) => {
-      return tf({ index: this.index });
+    utils.pipeTransforms(vfs.src([ filePath ]), transforms.map((tf) => {
+      return tf({
+        fetcher: this,
+        index: this.index
+      });
     }))
       .pipe(vfs.dest(path.dirname(filePath)))
       .on('error', (err) => reject(err))

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ function Fetcher (opts) {
   this.addTransform('html', require(path.join(__dirname, 'lib', 'transforms', 'html.localScriptSrcs')));
   this.addTransform('html', require(path.join(__dirname, 'lib', 'transforms', 'html.injectAppCacheIndex')));
   this.addTransform('html', require(path.join(__dirname, 'lib', 'transforms', 'html.injectRequireJsShim')));
+  this.addTransform('html', require(path.join(__dirname, 'lib', 'transforms', 'html.styleTransforms')));
 }
 
 Fetcher.prototype.addExtractor = function (prop, fn) {

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES5",
+    "allowSyntheticDefaultImports": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES5",
+    "target": "ES6",
     "allowSyntheticDefaultImports": true
   },
   "exclude": [

--- a/lib/extractors/requirejsSrc.js
+++ b/lib/extractors/requirejsSrc.js
@@ -3,6 +3,7 @@
 // Node.js built-ins
 
 var path = require('path');
+var url = require('url');
 
 // foreign modules
 
@@ -24,8 +25,9 @@ module.exports = function (opts) {
 
   js$ = js$.filter(function () {
     var src = $(this).attr('src');
-    src = utils.stripGZ('' + src);
-    return REQUIRE_BASE.indexOf(path.basename(src)) !== -1;
+    var parsed;
+    parsed = url.parse(utils.stripGZ('' + src), null, true);
+    return REQUIRE_BASE.indexOf(path.basename(parsed.pathname)) !== -1;
   });
 
   return js$.map(function () {

--- a/lib/transforms/css.localUrls.js
+++ b/lib/transforms/css.localUrls.js
@@ -5,9 +5,21 @@
 var path = require('path');
 var url = require('url');
 
+// local modules
+
+var streamify = require('../utils.js').streamify;
+
 // this module
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
   var filePath = opts.filePath;
   var index = opts.index;
@@ -15,7 +27,7 @@ module.exports = function (opts) {
   // original remote URL for the given CSS file
   var cssRemoteUrl = index.resolveRemoteUrl(path.basename(filePath));
 
-  return contents.replace(/url\(['"\s]*[^\(\)'"]+['"\s]*\)/g, function (cssUrlStmt) {
+  return contents.replace(/url\(['"\s]*[^\(\)'"]+['"\s]*\)/g, (cssUrlStmt) => {
     var cssUrl = cssUrlStmt.replace(/url\(['"\s]*([^\(\)'"]+)['"\s]*\)/, '$1');
     var remoteUrl;
     var localUrl;
@@ -26,4 +38,11 @@ module.exports = function (opts) {
     localUrl = index.resolveLocalUrl(remoteUrl);
     return 'url(' + localUrl + ')';
   });
-};
+}
+
+function cssLocalUrls (opts) {
+  return streamify(opts, transform);
+}
+
+module.exports = cssLocalUrls;
+module.exports.transform = transform;

--- a/lib/transforms/css.localUrls.js
+++ b/lib/transforms/css.localUrls.js
@@ -14,6 +14,7 @@ var streamify = require('../utils.js').streamify;
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.injectAppCacheIndex.js
+++ b/lib/transforms/html.injectAppCacheIndex.js
@@ -17,6 +17,7 @@ var streamify = require('../utils.js').streamify;
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.injectAppCacheIndex.js
+++ b/lib/transforms/html.injectAppCacheIndex.js
@@ -8,9 +8,21 @@ var path = require('path');
 
 var cheerio = require('cheerio');
 
+// local modules
+
+var streamify = require('../utils.js').streamify;
+
 // this module
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
   var filePath = opts.filePath;
 
@@ -19,4 +31,11 @@ module.exports = function (opts) {
     $('script').first().before('<script src="appCacheIndex.js"></script>');
   }
   return $.html();
-};
+}
+
+function htmlInjectAppCacheIndex (opts) {
+  return streamify(opts, transform);
+}
+
+module.exports = htmlInjectAppCacheIndex;
+module.exports.transform = transform;

--- a/lib/transforms/html.injectRequireJsShim.js
+++ b/lib/transforms/html.injectRequireJsShim.js
@@ -40,6 +40,7 @@ function findLastScript ($) {
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.injectRequireJsShim.js
+++ b/lib/transforms/html.injectRequireJsShim.js
@@ -18,7 +18,7 @@ var REQUIRE_BASE = ['require.js', 'require.min.js'];
 
 function findLastRequireScript ($) {
   return $('script[src], script[data-appcache-src]').filter(function () {
-    var src = utils.stripGZ('' + $(this).attr('src'));
+    var src = utils.stripGZ($(this).attr('src'));
     var oldSrc = utils.stripGZ($(this).attr('data-appcache-src'));
     return REQUIRE_BASE.indexOf(path.basename(src)) !== -1 ||
       REQUIRE_BASE.indexOf(path.basename(oldSrc)) !== -1;

--- a/lib/transforms/html.injectRequireJsShim.js
+++ b/lib/transforms/html.injectRequireJsShim.js
@@ -3,6 +3,7 @@
 // Node.js built-ins
 
 var path = require('path');
+var url = require('url');
 
 // foreign modules
 
@@ -18,10 +19,9 @@ var REQUIRE_BASE = ['require.js', 'require.min.js'];
 
 function findLastRequireScript ($) {
   return $('script[src], script[data-appcache-src]').filter(function () {
-    var src = utils.stripGZ($(this).attr('src'));
-    var oldSrc = utils.stripGZ($(this).attr('data-appcache-src'));
-    return REQUIRE_BASE.indexOf(path.basename(src)) !== -1 ||
-      REQUIRE_BASE.indexOf(path.basename(oldSrc)) !== -1;
+    var src = utils.stripGZ($(this).attr('data-appcache-src') || $(this).attr('src'));
+    var parsed = url.parse(src, false, true);
+    return REQUIRE_BASE.indexOf(path.basename(parsed.pathname)) !== -1;
   }).last();
 }
 

--- a/lib/transforms/html.injectRequireJsShim.js
+++ b/lib/transforms/html.injectRequireJsShim.js
@@ -37,7 +37,15 @@ function findLastScript ($) {
   return null;
 }
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
   var filePath = opts.filePath;
   var lastScript$;
@@ -52,4 +60,12 @@ module.exports = function (opts) {
     }
   }
   return $.html();
-};
+}
+
+function htmlInjectRequireJsShim (opts) {
+  return utils.streamify(opts, transform);
+}
+
+module.exports = htmlInjectRequireJsShim;
+module.exports.transform = transform;
+

--- a/lib/transforms/html.localLinkHrefs.js
+++ b/lib/transforms/html.localLinkHrefs.js
@@ -4,9 +4,21 @@
 
 var cheerio = require('cheerio');
 
+// local modules
+
+var streamify = require('../utils.js').streamify;
+
 // this module
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
   var index = opts.index;
 
@@ -23,4 +35,11 @@ module.exports = function (opts) {
     }
   });
   return $.html();
-};
+}
+
+function htmlLocalLinkHrefs (opts) {
+  return streamify(opts, transform);
+}
+
+module.exports = htmlLocalLinkHrefs;
+module.exports.transform = transform;

--- a/lib/transforms/html.localLinkHrefs.js
+++ b/lib/transforms/html.localLinkHrefs.js
@@ -13,6 +13,7 @@ var streamify = require('../utils.js').streamify;
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.localScriptSrcs.js
+++ b/lib/transforms/html.localScriptSrcs.js
@@ -4,13 +4,26 @@
 
 var cheerio = require('cheerio');
 
+// local modules
+
+var streamify = require('../utils.js').streamify;
+
 // this module
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
   var index = opts.index;
 
   var $ = cheerio.load(contents);
+
   $('script[src]').each(function () {
     var el$ = $(this);
     var href = el$.attr('src');
@@ -22,5 +35,13 @@ module.exports = function (opts) {
       });
     }
   });
+
   return $.html();
-};
+}
+
+function htmlLocalScriptSrcs (opts) {
+  return streamify(opts, transform);
+}
+
+module.exports = htmlLocalScriptSrcs;
+module.exports.transform = transform;

--- a/lib/transforms/html.localScriptSrcs.js
+++ b/lib/transforms/html.localScriptSrcs.js
@@ -13,6 +13,7 @@ var streamify = require('../utils.js').streamify;
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.removeManifest.js
+++ b/lib/transforms/html.removeManifest.js
@@ -13,6 +13,7 @@ var streamify = require('../utils.js').streamify;
 /*
 interface StringTransformOptions {
   contents: String,
+  fetcher: Fetcher,
   filePath: String,
   index: FetcherIndex
 }

--- a/lib/transforms/html.removeManifest.js
+++ b/lib/transforms/html.removeManifest.js
@@ -4,12 +4,31 @@
 
 var cheerio = require('cheerio');
 
+// local modules
+
+var streamify = require('../utils.js').streamify;
+
 // this module
 
-module.exports = function (opts) {
+/*
+interface StringTransformOptions {
+  contents: String,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
   var contents = opts.contents;
 
   var $ = cheerio.load(contents);
   $('html').removeAttr('manifest'); // drop AppCache manifest attributes
   return $.html();
-};
+}
+
+function htmlRemoveManifest (opts) {
+  return streamify(opts, transform);
+}
+
+module.exports = htmlRemoveManifest;
+module.exports.transform = transform;

--- a/lib/transforms/html.styleTransforms.js
+++ b/lib/transforms/html.styleTransforms.js
@@ -1,0 +1,125 @@
+'use strict';
+
+// Node.js built-ins
+
+var stream = require('stream');
+
+// 3rd-party modules
+
+var cheerio = require('cheerio');
+var VFile = require('vinyl');
+
+// local modules
+
+var utils = require('../utils.js');
+
+// this module
+
+// fileToReadable (file: VFile) => stream.Readable
+function fileToReadable (file) {
+  class VFileReadable extends stream.Readable {
+    _read () {
+      this.push(file);
+      this.push(null);
+    }
+  }
+  return new VFileReadable({ objectMode: true });
+}
+
+/**
+interface TransformDOMTextOptions {
+  filePath: String,
+  getText: (el$: CheerioElement) => String,
+  el$: CheerioElement,
+  setText: (el$: CheerioElement, text: String) => Void
+  transforms: stream.Transform[]
+}
+ */
+// transformText(opts: TransformTextOptions) => Promise
+function transformDOMText (opts) {
+  return new Promise((resolve, reject) => {
+    var file = new VFile({
+      path: opts.filePath,
+      contents: new Buffer(opts.getText(opts.el$), 'utf8')
+    });
+    var readable = fileToReadable(file);
+
+    utils.pipeTransforms(readable, opts.transforms)
+      .on('error', reject)
+      .on('end', () => {
+        opts.setText(opts.el$, file.contents.toString('utf8'));
+        resolve();
+      })
+      .resume();
+  });
+}
+
+// getAttrText (el$: CheerioElement) => String
+function getAttrText (el$) {
+  return el$.attr('style');
+}
+
+// setAttrText (el$: CheerioElement, text: String) => Void
+function setAttrText (el$, text) {
+  el$.attr('style', text);
+}
+
+// getTagText (el$: CheerioElement) => String
+function getTagText (el$) {
+  return el$.text();
+}
+
+// setTagText (el$: CheerioElement, text: String) => Void
+function setTagText (el$, text) {
+  el$.text(text);
+}
+
+/*
+interface StringTransformOptions {
+  contents: String,
+  fetcher: Fetcher,
+  filePath: String,
+  index: FetcherIndex
+}
+*/
+// transform (opts: StringTransformOptions) => String
+function transform (opts) {
+  var contents = opts.contents;
+
+  var $ = cheerio.load(contents);
+
+  var cssTransforms = opts.fetcher.transforms.css.map((tf) => tf({
+    fetcher: opts.fetcher,
+    index: opts.index
+  }));
+
+  // start parallel processing streams, one for each style tag
+  var tasks = [].concat(
+    // style attributes
+    $('[style]').toArray().map((el) => transformDOMText({
+      filePath: opts.filePath,
+      getText: getAttrText, // get from attribute
+      el$: $(el),
+      setText: setAttrText, // set attribute
+      transforms: cssTransforms
+    })),
+    // style tags
+    $('style').toArray().map((el) => transformDOMText({
+      filePath: opts.filePath,
+      getText: getTagText, // get from textContent
+      el$: $(el),
+      setText: setTagText, // set textContent
+      transforms: cssTransforms
+    }))
+  );
+  return Promise.all(tasks)
+    // all styles have been processed, output correct HTML
+    .then(() => $.html());
+}
+
+function htmlStyleTransforms (opts) {
+  return utils.streamify(opts, transform);
+}
+
+module.exports = htmlStyleTransforms;
+module.exports.transform = transform;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,7 @@ var url = require('url');
 
 // foreign modules
 
+var isPromise = require('is-promise');
 var through2 = require('through2');
 
 // local modules
@@ -21,18 +22,31 @@ function streamify (opts, transform) {
     // (vfile: VinylFile, enc: String, cb: Function)
     (vfile, enc, cb) => {
       var contents = vfile.contents.toString(enc);
+      var result;
+      var onSuccess = (contents) => {
+        vfile.contents = new Buffer(contents, enc);
+        cb(null, vfile);
+      };
+      var onError = (err) => {
+        cb(err);
+      };
       try {
-        contents = transform({
+        result = transform({
           contents: contents,
           filePath: vfile.path,
           index: opts.index
         });
-        vfile.contents = new Buffer(contents, enc);
       } catch (err) {
-        cb(err);
+        onError(err);
         return;
       }
-      cb(null, vfile);
+      if (isPromise(result)) {
+        result
+          .then(onSuccess)
+          .catch(onError);
+        return;
+      }
+      onSuccess(result);
     }
   );
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,6 @@
 
 // Node.js built-in
 
-var path = require('path');
 var url = require('url');
 
 // foreign modules
@@ -73,12 +72,20 @@ module.exports = {
   @returns {String} without ".gz" in it
   */
   stripGZ: function (urlString) {
-    var basename;
+    var parsed, segments, basename;
     if (!urlString || typeof urlString !== 'string') {
       return '';
     }
-    basename = path.basename(urlString);
-    return path.dirname(urlString) + '/' + basename.replace(/\.gz\b/g, '');
+    parsed = url.parse(urlString, false, true);
+    if (!parsed.pathname || parsed.pathname === '/') {
+      return urlString;
+    }
+    segments = parsed.pathname.split('/');
+    basename = segments.pop();
+    basename = basename.replace(/\.gz\b/g, '');
+    segments.push(basename);
+    parsed.pathname = segments.join('/');
+    return url.format(parsed);
   },
 
   streamify,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -18,7 +18,11 @@ module.exports = {
   @returns {String} without ".gz" in it
   */
   stripGZ: function (urlString) {
-    var basename = path.basename(urlString);
+    var basename;
+    if (!urlString || typeof urlString !== 'string') {
+      return '';
+    }
+    basename = path.basename(urlString);
     return path.dirname(urlString) + '/' + basename.replace(/\.gz\b/g, '');
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,11 +5,37 @@
 var path = require('path');
 var url = require('url');
 
+// foreign modules
+
+var through2 = require('through2');
+
 // local modules
 
 var values = require('./values');
 
 // this module
+
+// streamify ({ index: FetcherIndex }, transform: Function) => Stream
+function streamify (opts, transform) {
+  return through2.obj(
+    // (vfile: VinylFile, enc: String, cb: Function)
+    (vfile, enc, cb) => {
+      var contents = vfile.contents.toString(enc);
+      try {
+        contents = transform({
+          contents: contents,
+          filePath: vfile.path,
+          index: opts.index
+        });
+        vfile.contents = new Buffer(contents, enc);
+      } catch (err) {
+        cb(err);
+        return;
+      }
+      cb(null, vfile);
+    }
+  );
+}
 
 module.exports = {
 
@@ -25,6 +51,8 @@ module.exports = {
     basename = path.basename(urlString);
     return path.dirname(urlString) + '/' + basename.replace(/\.gz\b/g, '');
   },
+
+  streamify,
 
   /**
   intended to be used with `Array#filter()`

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,18 @@ var values = require('./values');
 
 // this module
 
+// pipeTransforms (stream: Readable, transforms: Transforms[]) => Readable
+function pipeTransforms (stream, transforms) {
+  var head, rest;
+  if (!Array.isArray(transforms) || !transforms.length) {
+    return stream;
+  }
+  head = transforms[0];
+  rest = transforms.slice(1);
+  // recursively pipe to remaining Transforms
+  return pipeTransforms(stream.pipe(head), rest);
+}
+
 // streamify ({ index: FetcherIndex }, transform: Function) => Stream
 function streamify (opts, transform) {
   return through2.obj(
@@ -33,6 +45,7 @@ function streamify (opts, transform) {
       try {
         result = transform({
           contents: contents,
+          fetcher: opts.fetcher,
           filePath: vfile.path,
           index: opts.index
         });
@@ -52,6 +65,8 @@ function streamify (opts, transform) {
 }
 
 module.exports = {
+
+  pipeTransforms,
 
   /**
   @param {String} urlString to remove things like ".gz"

--- a/package.json
+++ b/package.json
@@ -11,11 +11,11 @@
     "lodash.uniq": "^4.0.1",
     "mkdirp": "0.5.1",
     "pify": "2.3.0",
-    "request": "2.69.0",
+    "request": "2.72.0",
     "temp": "0.8.3"
   },
   "devDependencies": {
-    "ava": "^0.13.0",
+    "ava": "^0.15.2",
     "eslint": "^2.7.0",
     "eslint-config-semistandard": "^6.0.1",
     "eslint-config-standard": "^5.1.0",
@@ -23,7 +23,7 @@
     "eslint-plugin-standard": "^1.2",
     "fixpack": "^2.2.0",
     "hapi": "^13.3.0",
-    "inert": "^3.2.0",
+    "inert": "^4.0.0",
     "mockery": "^1.4.0",
     "nyc": "^6.1.1",
     "rimraf": "^2.3"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "browserify": "11.0.1",
     "chalk": "^1.1.1",
     "cheerio": "^0.20.0",
-    "cyclonejs": "1.1.3",
     "graceful-fs": "^4.1.2",
     "lodash.uniq": "^4.0.1",
     "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "tests"
   },
   "engines": {
-    "node": ">=0.12",
+    "node": ">=4",
     "npm": ">=3.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "request": "2.72.0",
     "temp": "0.8.3",
     "through2": "2.0.1",
+    "vinyl": "1.1.1",
     "vinyl-fs": "2.4.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@jokeyrhyme/appcache-fetcher",
   "description": "store an AppCache-enabled site on disk for local use",
   "version": "1.3.2",
+  "bugs": {
+    "url": "https://github.com/jokeyrhyme/appcache-fetcher.js/issues"
+  },
   "dependencies": {
     "@jokeyrhyme/appcache": "1.0.0",
     "browserify": "11.0.1",
@@ -28,6 +31,9 @@
     "nyc": "^6.1.1",
     "rimraf": "^2.3"
   },
+  "directories": {
+    "test": "tests"
+  },
   "engines": {
     "node": ">=0.12",
     "npm": ">=3.0"
@@ -39,8 +45,16 @@
     "lib",
     "www"
   ],
+  "homepage": "https://github.com/jokeyrhyme/appcache-fetcher.js#readme",
+  "keywords": [
+    "appcache",
+    "fetch"
+  ],
   "license": "BSD-2-Clause",
   "main": "index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/jokeyrhyme/appcache-fetcher.js.git"
@@ -51,20 +65,5 @@
     "nyc": "nyc check-coverage -f 90 -l 90 -s 90",
     "posttest": "npm run nyc && npm run eslint && npm run fixpack",
     "test": "nyc ava tests/*.js"
-  },
-  "bugs": {
-    "url": "https://github.com/jokeyrhyme/appcache-fetcher.js/issues"
-  },
-  "homepage": "https://github.com/jokeyrhyme/appcache-fetcher.js#readme",
-  "directories": {
-    "test": "tests"
-  },
-  "keywords": [
-      "appcache",
-      "fetch"
-  ],
-  "author": "",
-  "publishConfig": {
-    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@jokeyrhyme/appcache": "1.0.0",
-    "browserify": "11.0.1",
+    "browserify": "13.0.1",
     "chalk": "^1.1.1",
     "cheerio": "^0.20.0",
     "graceful-fs": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -41,12 +41,30 @@
   ],
   "license": "BSD-2-Clause",
   "main": "index.js",
-  "repository": "https://github.com/jokeyrhyme/appcache-fetcher.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jokeyrhyme/appcache-fetcher.js.git"
+  },
   "scripts": {
-    "eslint": "eslint --fix .",
+    "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
     "nyc": "nyc check-coverage -f 90 -l 90 -s 90",
     "posttest": "npm run nyc && npm run eslint && npm run fixpack",
     "test": "nyc ava tests/*.js"
+  },
+  "bugs": {
+    "url": "https://github.com/jokeyrhyme/appcache-fetcher.js/issues"
+  },
+  "homepage": "https://github.com/jokeyrhyme/appcache-fetcher.js#readme",
+  "directories": {
+    "test": "tests"
+  },
+  "keywords": [
+      "appcache",
+      "fetch"
+  ],
+  "author": "",
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "chalk": "^1.1.1",
     "cheerio": "^0.20.0",
     "graceful-fs": "^4.1.2",
+    "is-promise": "2.1.0",
     "lodash.uniq": "^4.0.1",
     "mkdirp": "0.5.1",
     "pify": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "mkdirp": "0.5.1",
     "pify": "2.3.0",
     "request": "2.72.0",
-    "temp": "0.8.3"
+    "temp": "0.8.3",
+    "through2": "2.0.1",
+    "vinyl-fs": "2.4.3"
   },
   "devDependencies": {
     "ava": "^0.15.2",

--- a/tests/css.localUrls.js
+++ b/tests/css.localUrls.js
@@ -11,7 +11,7 @@ var test = require('ava');
 
 // local modules
 
-var cssLocalUrls = require('../lib/transforms/css.localUrls.js');
+var cssLocalUrls = require('../lib/transforms/css.localUrls.js').transform;
 var FetcherIndex = require('../www/fetcher-index.js');
 
 // this module

--- a/tests/e2e-devdocs.js
+++ b/tests/e2e-devdocs.js
@@ -33,13 +33,13 @@ test.before(function (t) {
 });
 
 test.serial('constructor', function (t) {
-  t.doesNotThrow(function () {
+  t.notThrows(function () {
     fetcher = new Fetcher({
       remoteUrl: remoteUrl,
       localPath: outputPath
     });
   });
-  t.ok(fetcher);
+  t.truthy(fetcher);
 });
 
 test.serial('.go()', function (t) {
@@ -49,10 +49,10 @@ test.serial('.go()', function (t) {
 test.serial('index.html', function (t) {
   var contents;
   var $;
-  t.ok(fs.existsSync(path.join(outputPath, 'index.html')));
+  t.truthy(fs.existsSync(path.join(outputPath, 'index.html')));
   contents = fs.readFileSync(path.join(outputPath, 'index.html'), { encoding: 'utf8' });
   $ = cheerio.load(contents);
-  t.notOk($('html').attr('manifest'), 'no AppCache manifest attribute');
+  t.falsy($('html').attr('manifest'), 'no AppCache manifest attribute');
   // these tests fail because of weird URLs in HTML / AppCache (?yyyymmdd)
   // common.testHTMLLinkHref($, t);
   common.testHTMLScriptSrc($, t);

--- a/tests/e2e-everytimezone.js
+++ b/tests/e2e-everytimezone.js
@@ -34,13 +34,13 @@ test.before(function (t) {
 });
 
 test.serial('constructor', function (t) {
-  t.doesNotThrow(function () {
+  t.notThrows(function () {
     fetcher = new Fetcher({
       remoteUrl: remoteUrl,
       localPath: relativeOutputPath
     });
   });
-  t.ok(fetcher);
+  t.truthy(fetcher);
 });
 
 test.serial('.go()', function (t) {
@@ -50,10 +50,10 @@ test.serial('.go()', function (t) {
 test.serial('index.html', function (t) {
   var contents;
   var $;
-  t.ok(fs.existsSync(path.join(outputPath, 'index.html')));
+  t.truthy(fs.existsSync(path.join(outputPath, 'index.html')));
   contents = fs.readFileSync(path.join(outputPath, 'index.html'), { encoding: 'utf8' });
   $ = cheerio.load(contents);
-  t.notOk($('html').attr('manifest'), 'no AppCache manifest attribute');
+  t.falsy($('html').attr('manifest'), 'no AppCache manifest attribute');
   common.testHTMLLinkHref($, t);
   // these tests fail because of weird URLs in HTML / AppCache (?yyyymmdd)
   // common.testHTMLScriptSrc($, t);

--- a/tests/embedded-css.js
+++ b/tests/embedded-css.js
@@ -1,0 +1,94 @@
+'use strict';
+
+// Node.js built-ins
+
+var fs = require('fs');
+var path = require('path');
+var url = require('url');
+
+// foreign modules
+
+var pify = require('pify');
+var temp = pify(require('temp').track());
+var test = require('ava');
+
+// local modules
+
+var Fetcher = require('..');
+var pkg = require('../package.json');
+var server = require('./fixtures/server');
+
+// this module
+
+var fsp = pify(fs);
+
+var FIXTURE_PATH = path.join(__dirname, 'fixtures', 'embedded-css');
+var REMOTE_URL;
+
+var AVAILABLE_RESOURCES = [
+  'background.svg'
+];
+
+test.before(function () {
+  return server.start({ port: 3002 })
+    .then(function (origin) {
+      REMOTE_URL = origin + '/embedded-css/';
+    });
+});
+
+test.after(function () {
+  return server.stop();
+});
+
+test.beforeEach((t) => {
+  return temp.mkdir(pkg.name.replace(/\//g, '-') + '-')
+    .then((dirPath) => {
+      t.context.tempDir = dirPath;
+      t.context.fetcher = new Fetcher({
+        localPath: dirPath,
+        remoteUrl: REMOTE_URL
+      });
+    });
+});
+
+test.serial('fetcher.go()', function (t) {
+  return t.context.fetcher.go();
+});
+
+var index;
+
+test.serial('index.json populated correctly', function (t) {
+  return t.context.fetcher.go()
+    .then(function () {
+      index = require(path.join(t.context.tempDir, 'index.json'));
+      var remoteUrls = Object.keys(index);
+
+      AVAILABLE_RESOURCES.map(function (resource) {
+        return url.resolve(REMOTE_URL, resource);
+      }).forEach(function (resource) {
+        t.truthy(~remoteUrls.indexOf(resource));
+      });
+    });
+});
+
+test.serial('index.html downloaded and processed', function (t) {
+  return t.context.fetcher.go()
+    .then(function () {
+      return Promise.all([
+        fsp.readFile(path.join(t.context.tempDir, 'index.html'), 'utf8'),
+        fsp.readFile(path.join(FIXTURE_PATH, 'index.html'), 'utf8')
+      ]);
+    })
+    .then(function (results) {
+      var stored = results[0];
+      var original = results[1];
+
+      t.not(stored, original);
+
+      // confirm that available resources were properly substituted
+      AVAILABLE_RESOURCES.forEach(function (resource) {
+        t.falsy(~stored.indexOf('url(' + resource + ')'));
+        t.truthy(~stored.indexOf('url(' + index[url.resolve(REMOTE_URL, resource)] + ')'));
+      });
+    });
+});

--- a/tests/embedded-css.js
+++ b/tests/embedded-css.js
@@ -9,7 +9,7 @@ var url = require('url');
 // foreign modules
 
 var pify = require('pify');
-var temp = pify(require('temp').track());
+var temp = pify(require('temp'));
 var test = require('ava');
 
 // local modules
@@ -19,6 +19,11 @@ var pkg = require('../package.json');
 var server = require('./fixtures/server');
 
 // this module
+
+// CIs don't need this auto-teardown, just developer machines
+if (!process.env.CI) {
+  temp.track();
+}
 
 var fsp = pify(fs);
 

--- a/tests/extractor-requirejssrc.js
+++ b/tests/extractor-requirejssrc.js
@@ -18,7 +18,7 @@ test('html with no Require.js', function (t) {
   var html = '<html><script src="blah.js"></script></html>';
 
   var srcs = requirejsSrc({ contents: html });
-  t.ok(Array.isArray(srcs));
+  t.truthy(Array.isArray(srcs));
   t.is(srcs.length, 0);
 });
 
@@ -26,7 +26,7 @@ test('html with Require.js', function (t) {
   var html = '<html><script src="//cdn/require.min.js"></script><script src="blah.js"></script></html>';
 
   var srcs = requirejsSrc({ contents: html });
-  t.ok(Array.isArray(srcs));
+  t.truthy(Array.isArray(srcs));
   t.is(srcs.length, 1);
-  t.same(srcs, ['//cdn/require.min.js']);
+  t.deepEqual(srcs, ['//cdn/require.min.js']);
 });

--- a/tests/fetcher.geturlvariations.js
+++ b/tests/fetcher.geturlvariations.js
@@ -25,7 +25,7 @@ test('Fetcher', function (t) {
 
 test('https://domain.com/example', function (t) {
   var variations = Fetcher.getURLVariationsOnScheme('https://domain.com/example');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'https://domain.com/example',
     'http://domain.com/example'
   ]);
@@ -33,7 +33,7 @@ test('https://domain.com/example', function (t) {
 
 test('http://domain.com/example', function (t) {
   var variations = Fetcher.getURLVariations('http://domain.com/example');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'https://domain.com/example',
     'http://domain.com/example'
   ]);
@@ -41,7 +41,7 @@ test('http://domain.com/example', function (t) {
 
 test('https://domain.com/example', function (t) {
   var variations = Fetcher.getURLVariationsOnScheme('https://domain.com/example');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'https://domain.com/example',
     'http://domain.com/example'
   ]);
@@ -49,7 +49,7 @@ test('https://domain.com/example', function (t) {
 
 test('http://domain.com/example', function (t) {
   var variations = Fetcher.getURLVariations('http://domain.com/example');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'https://domain.com/example',
     'http://domain.com/example'
   ]);
@@ -57,7 +57,7 @@ test('http://domain.com/example', function (t) {
 
 test('http://domain.com/example?abc&def=ghi', function (t) {
   var variations = Fetcher.getURLVariationsOnQuery('http://domain.com/example?abc&def=ghi');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'http://domain.com/example?abc&def=ghi',
     'http://domain.com/example?def=ghi',
     'http://domain.com/example?abc=',
@@ -67,7 +67,7 @@ test('http://domain.com/example?abc&def=ghi', function (t) {
 
 test('http://domain.com/example?abc&def=ghi', function (t) {
   var variations = Fetcher.getURLVariations('http://domain.com/example?abc&def=ghi');
-  t.same(variations, [
+  t.deepEqual(variations, [
     'https://domain.com/example?abc&def=ghi',
     'http://domain.com/example?abc&def=ghi'
     // disable this for now

--- a/tests/fixtures/embedded-css/index.html
+++ b/tests/fixtures/embedded-css/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en" manifest="manifest.appcache">
+<head>
+  <meta charset="UTF-8" />
+  <title>missing-resource</title>
+  <style>
+    body {
+      background-image: url(background.svg);
+    }
+  </style>
+</head>
+<body>
+  <div style="background-image: url(background.svg);"></div>
+</body>
+</html>

--- a/tests/fixtures/embedded-css/manifest.appcache
+++ b/tests/fixtures/embedded-css/manifest.appcache
@@ -1,0 +1,4 @@
+CACHE MANIFEST
+
+CACHE:
+background.svg

--- a/tests/helpers/common.js
+++ b/tests/helpers/common.js
@@ -19,18 +19,18 @@ module.exports = {
 
   makeAppCacheTests: function (outputPath) {
     test.serial('appcache.manifest', function (tt) {
-      tt.ok(fs.existsSync(path.join(outputPath, 'appcache.manifest')));
+      tt.truthy(fs.existsSync(path.join(outputPath, 'appcache.manifest')));
     });
 
     test.serial('appcache.json', function (tt) {
       var appCache;
-      tt.ok(fs.existsSync(path.join(outputPath, 'appcache.json')));
-      tt.doesNotThrow(function () {
+      tt.truthy(fs.existsSync(path.join(outputPath, 'appcache.json')));
+      tt.notThrows(function () {
         delete require.cache[path.join(outputPath, 'appcache.json')];
         appCache = require(path.join(outputPath, 'appcache.json'));
       });
       tt.is(typeof appCache, 'object');
-      tt.ok(Array.isArray(appCache.cache));
+      tt.truthy(Array.isArray(appCache.cache));
     });
   },
 
@@ -55,7 +55,7 @@ module.exports = {
             ttt.not(cssUrl.indexOf('//'), 0, cssUrl + ' not protocol-relative');
             ttt.not(cssUrl.indexOf('http://'), 0, cssUrl + ' not remote HTTP');
             ttt.not(cssUrl.indexOf('https://'), 0, cssUrl + ' not remote HTTPS');
-            ttt.ok(fs.existsSync(path.join(outputPath, cssUrl)), cssUrl + ' local exists');
+            ttt.truthy(fs.existsSync(path.join(outputPath, cssUrl)), cssUrl + ' local exists');
           });
         }
       });
@@ -64,7 +64,7 @@ module.exports = {
 
   makeJavaScriptTests: function (outputPath) {
     test.serial('appCacheIndex.js exists', function (tt) {
-      tt.ok(fs.existsSync(path.join(outputPath, 'appCacheIndex.js')));
+      tt.truthy(fs.existsSync(path.join(outputPath, 'appCacheIndex.js')));
     });
 
     // __dirname is a symptom of weird module paths that break in the app
@@ -77,7 +77,7 @@ module.exports = {
     });
 
     test.serial('require.load.js exists', function (tt) {
-      tt.ok(fs.existsSync(path.join(outputPath, 'require.load.js')));
+      tt.truthy(fs.existsSync(path.join(outputPath, 'require.load.js')));
     });
 
     // __dirname is a symptom of weird module paths that break in the app
@@ -93,8 +93,8 @@ module.exports = {
   makeIndexJSONTests: function (outputPath, remoteUrl) {
     test.serial('index.json', function (tt) {
       var index;
-      tt.ok(fs.existsSync(path.join(outputPath, 'index.json')));
-      tt.doesNotThrow(function () {
+      tt.truthy(fs.existsSync(path.join(outputPath, 'index.json')));
+      tt.notThrows(function () {
         delete require.cache[path.join(outputPath, 'index.json')];
         index = require(path.join(outputPath, 'index.json'));
       });
@@ -108,7 +108,7 @@ module.exports = {
       var el$ = $(this);
       var href = el$.attr('href');
       if (href) {
-        tt.ok(el$.attr('data-appcache-href'));
+        tt.truthy(el$.attr('data-appcache-href'));
         tt.not(href.indexOf('//'), 0);
         tt.not(href.indexOf('http://'));
         tt.not(href.indexOf('https://'));
@@ -121,7 +121,7 @@ module.exports = {
       var el$ = $(this);
       var href = el$.attr('src');
       if (href && NEW_JS.indexOf(href) === -1) {
-        tt.ok(el$.attr('data-appcache-src'));
+        tt.truthy(el$.attr('data-appcache-src'));
         tt.not(href.indexOf('//'), 0);
         tt.not(href.indexOf('http://'));
         tt.not(href.indexOf('https://'));

--- a/tests/missing-resource-sloppy.js
+++ b/tests/missing-resource-sloppy.js
@@ -68,7 +68,7 @@ test.serial('index.json populated correctly', function (t) {
       AVAILABLE_RESOURCES.map(function (resource) {
         return url.resolve(REMOTE_URL, resource);
       }).forEach(function (resource) {
-        t.ok(~remoteUrls.indexOf(resource));
+        t.truthy(~remoteUrls.indexOf(resource));
       });
     });
 });
@@ -89,10 +89,10 @@ test.serial('index.html downloaded and processed', function (t) {
 
       // confirm that available resources were properly substituted
       AVAILABLE_RESOURCES.forEach(function (resource) {
-        t.notOk(~stored.indexOf(' src="' + resource + '"'));
-        t.ok(~stored.indexOf(' data-appcache-src="' + resource + '"'));
+        t.falsy(~stored.indexOf(' src="' + resource + '"'));
+        t.truthy(~stored.indexOf(' data-appcache-src="' + resource + '"'));
       });
 
-      t.ok(/\ssrc="[^"]+missing\.js"/.test(stored));
+      t.truthy(/\ssrc="[^"]+missing\.js"/.test(stored));
     });
 });

--- a/tests/missing-resource-sloppy.js
+++ b/tests/missing-resource-sloppy.js
@@ -9,7 +9,7 @@ var url = require('url');
 // foreign modules
 
 var pify = require('pify');
-var temp = pify(require('temp').track());
+var temp = pify(require('temp'));
 var test = require('ava');
 
 // local modules
@@ -19,6 +19,11 @@ var pkg = require('../package.json');
 var server = require('./fixtures/server');
 
 // this module
+
+// CIs don't need this auto-teardown, just developer machines
+if (!process.env.CI) {
+  temp.track();
+}
 
 var fsp = pify(fs);
 

--- a/tests/missing-resource-strict.js
+++ b/tests/missing-resource-strict.js
@@ -49,14 +49,14 @@ test.beforeEach((t) => {
 test.serial('fetcher.go() fails', function (t) {
   return t.context.fetcher.go()
     .catch(function (err) {
-      t.ok(err);
+      t.truthy(err);
     });
 });
 
 test.serial('index.html downloaded and unmodified', function (t) {
   return t.context.fetcher.go()
     .catch(function (err) {
-      t.ok(err);
+      t.truthy(err);
     })
     .then(function () {
       return Promise.all([

--- a/tests/missing-resource-strict.js
+++ b/tests/missing-resource-strict.js
@@ -8,7 +8,7 @@ var path = require('path');
 // foreign modules
 
 var pify = require('pify');
-var temp = pify(require('temp').track());
+var temp = pify(require('temp'));
 var test = require('ava');
 
 // local modules
@@ -18,6 +18,11 @@ var pkg = require('../package.json');
 var server = require('./fixtures/server');
 
 // this module
+
+// CIs don't need this auto-teardown, just developer machines
+if (!process.env.CI) {
+  temp.track();
+}
 
 var fsp = pify(fs);
 

--- a/tests/protocol_whitelist.js
+++ b/tests/protocol_whitelist.js
@@ -24,7 +24,7 @@ test.serial.cb('load fixture: data-uri.appcache', function (t) {
   fs.readFile(filePath, { encoding: 'utf8' }, function (err, contents) {
     t.error(err);
     fixture = contents;
-    t.ok(fixture);
+    t.truthy(fixture);
     t.is(typeof fixture, 'string');
     t.end();
   });
@@ -33,7 +33,7 @@ test.serial.cb('load fixture: data-uri.appcache', function (t) {
 test.serial.cb('Fetcher#saveAppCacheAsJSON() -> #writeFile()', function (t) {
   fetcher.writeFile = function (filePath, json) {
     parsed = JSON.parse(json);
-    t.ok(parsed);
+    t.truthy(parsed);
     t.is(typeof parsed, 'object');
     t.end();
   };
@@ -42,7 +42,7 @@ test.serial.cb('Fetcher#saveAppCacheAsJSON() -> #writeFile()', function (t) {
 
 test.serial.cb('parsed JSON has expected content', function (t) {
   t.is(parsed.cache.length, 3, 'all 3 CACHE entries found');
-  t.same(parsed.cache, [
+  t.deepEqual(parsed.cache, [
     'http://google.com/',
     'https://github.com/',
     'image.jpeg'

--- a/tests/shim-jquery.ajax.js
+++ b/tests/shim-jquery.ajax.js
@@ -25,25 +25,25 @@ test('empty index', function (t) {
   require(path.join(__dirname, '..', 'www', 'shims', 'jquery.ajax'))(fetcherIndex, $, 'ajax');
 
   args = [];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [ { method: 'GET' } ];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [
     'http://example.com/remote-abc.js',
     { method: 'GET' }
   ];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [ { url: 'http://example.com/remote-abc.js', method: 'GET' } ];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [
     'http://example.com/remote-abc.js',
     { url: 'http://example.com/remote-def.js', method: 'GET' }
   ];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 });
 
 test('matching index', function (t) {
@@ -58,10 +58,10 @@ test('matching index', function (t) {
   fetcherIndex.set('http://example.com/remote-def.js', 'local-def.js');
 
   args = [];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [ { method: 'GET' } ];
-  t.same($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
+  t.deepEqual($.ajax.apply($, args), args, JSON.stringify(args) + ': noop');
 
   args = [
     'http://example.com/remote-abc.js',
@@ -71,11 +71,11 @@ test('matching index', function (t) {
     'local-abc.js',
     { method: 'GET' }
   ];
-  t.same($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
+  t.deepEqual($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
 
   args = [ { url: 'http://example.com/remote-abc.js', method: 'GET' } ];
   expected = [ { url: 'local-abc.js', method: 'GET' } ];
-  t.same($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
+  t.deepEqual($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
 
   args = [
     'http://example.com/remote-abc.js',
@@ -85,5 +85,5 @@ test('matching index', function (t) {
     'local-abc.js',
     { url: 'local-def.js', method: 'GET' }
   ];
-  t.same($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
+  t.deepEqual($.ajax.apply($, args), expected, JSON.stringify(args) + ': correct');
 });

--- a/tests/transform-html.injectRequireJsShim.js
+++ b/tests/transform-html.injectRequireJsShim.js
@@ -10,7 +10,7 @@ var test = require('ava');
 
 // our modules
 
-var injectRequireJsShim = require(path.join(__dirname, '..', 'lib', 'transforms', 'html.injectRequireJsShim'));
+var injectRequireJsShim = require(path.join(__dirname, '..', 'lib', 'transforms', 'html.injectRequireJsShim')).transform;
 
 // this module
 

--- a/tests/utils-stripgz.js
+++ b/tests/utils-stripgz.js
@@ -22,9 +22,9 @@ test('utils.stripGZ', function (t) {
   t.is(fn('/just/path/file.js'), '/just/path/file.js');
   t.is(fn('/just/path/file.js.gz'), '/just/path/file.js');
   t.is(fn('/just/path/file.gz.js'), '/just/path/file.js');
-  t.is(fn('https://file.js'), 'https://file.js');
-  t.is(fn('https://file.js.gz'), 'https://file.js');
-  t.is(fn('https://file.gz.js'), 'https://file.js');
+  t.is(fn('https://abc.xyz/file.js'), 'https://abc.xyz/file.js');
+  t.is(fn('https://abc.xyz/file.js.gz'), 'https://abc.xyz/file.js');
+  t.is(fn('https://abc.xyz/file.gz.js'), 'https://abc.xyz/file.js');
   t.is(fn(undefined), '');
   t.is(fn(null), '');
 });

--- a/tests/utils-stripgz.js
+++ b/tests/utils-stripgz.js
@@ -25,4 +25,6 @@ test('utils.stripGZ', function (t) {
   t.is(fn('https://file.js'), 'https://file.js');
   t.is(fn('https://file.js.gz'), 'https://file.js');
   t.is(fn('https://file.gz.js'), 'https://file.js');
+  t.is(fn(undefined), '');
+  t.is(fn(null), '');
 });

--- a/www/.eslintrc.json
+++ b/www/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": {
+    "ecmaVersion": 5
+  }
+}

--- a/www/fetcher-index.js
+++ b/www/fetcher-index.js
@@ -24,18 +24,19 @@ FetcherIndex.prototype.set = function (remoteUrl, localUrl) {
 };
 
 FetcherIndex.prototype.resolveRemoteUrl = function (localUrl) {
-  var me = this;
-  var remoteUrl;
-  Object.keys(this.index).forEach(function (key) {
-    if (me.index[key] === localUrl) {
-      remoteUrl = key;
+  var candidates = Object.keys(this.index);
+  var key, c, cLength;
+  cLength = candidates.length;
+  for (c = 0; c < cLength; c += 1) {
+    key = candidates[c];
+    if (this.index[key] === localUrl) {
+      return key;
     }
-  });
-  return remoteUrl || null;
+  }
+  return null;
 };
 
 FetcherIndex.prototype.resolveLocalUrl = function (remoteUrl) {
-  var me = this;
   var absUrl;
   var localHref;
   var variations, v, vLength, variation;
@@ -45,7 +46,7 @@ FetcherIndex.prototype.resolveLocalUrl = function (remoteUrl) {
   vLength = variations.length;
   for (v = 0; v < vLength; v++) {
     variation = variations[v];
-    localHref = me.index[variation];
+    localHref = this.index[variation];
     if (localHref) {
       return localHref;
     }

--- a/www/shims/jquery.html.js
+++ b/www/shims/jquery.html.js
@@ -21,7 +21,7 @@ module.exports = function (index, context, method) {
 
   var fixHtml = function (value) {
     if (value && typeof value === 'string') {
-      value = value.replace(/<img[-_\s\=\"\'\.\/\:\w]* src="([-_\.\/\:\w]+)"/gmi, fixSrc);
+      value = value.replace(/<img[-_\s="'\.\/:\w]* src="([-_\.\/:\w]+)"/gmi, fixSrc);
     }
 
     return value;

--- a/www/url_variations.js
+++ b/www/url_variations.js
@@ -6,7 +6,6 @@ var url = require('url');
 
 // 3rd-party modules
 
-var clone = require('cyclonejs').clone;
 var uniq = require('lodash.uniq');
 
 // this module
@@ -18,7 +17,7 @@ exports.getURLVariationsOnQuery = function (input, isSub) {
   output.push(input);
   delete parsed.search;
   Object.keys(oldQuery).forEach(function (key) {
-    var newQuery = clone(oldQuery);
+    var newQuery = JSON.parse(JSON.stringify(oldQuery));
     var subVariations;
     delete newQuery[key];
     parsed.query = newQuery;


### PR DESCRIPTION
### Changed

- officially drop support for anything older than Node.js 4

- ACF-11: run CSS transforms on styles within HTML (#14, @jokeyrhyme)

    - this includes the content of STYLE tags, and the content of "style" attributes on tags

- ACF-11: transforms are now passed the Fetcher instance itself

    - allows transforms to access other transforms, for example

- ACF-11: transforms are expected to be proper [`stream.Transform`](https://nodejs.org/dist/latest-v4.x/docs/api/stream.html#stream_class_stream_transform) streams

    - see the [through2](https://github.com/rvagg/through2) documentation for examples

- ACF-11: transforms are expected to be able to consume [vinyl](https://github.com/gulpjs/vinyl) `File` objects, just like [gulp](https://github.com/gulpjs/gulp) plugins

- drop a dependency on [cyclonejs](https://github.com/traviskaufman/cycloneJS), our use case doesn't require `Object`s to be cloned quite so thoroughly


### Fixed

- the ".gz" stripping algorithm now avoids platform-specific behaviours in the built-in "path" module

- the Require.js extractor and shimming-transform now avoid platform-specific behaviours in the built-in "path" module


### Code Review Notes

- definitely take a look at each commit, as it'll be easier to understand smaller chunks of changes