### PR TITLE
ACF-12 # Revert Browserify to 11.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@jokeyrhyme/appcache": "1.0.0",
-    "browserify": "13.0.1",
+    "browserify": "11.0.1",
     "chalk": "^1.1.1",
     "cheerio": "^0.20.0",
     "graceful-fs": "^4.1.2",


### PR DESCRIPTION
Turns out it was browserify, but i needed to clean my npm modules up and reference local files before I could get 11.0.1 to install.

This fixes the ACF for android. I'm getting a winJS error when trying to build windows but that may be my system, I have winjs 4.4 which needs to be `require`d in